### PR TITLE
Move all apps to cmd

### DIFF
--- a/cmd/builder/builder.go
+++ b/cmd/builder/builder.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/blankon/irgsh-go/pkg/systemutil"
+	"gopkg.in/src-d/go-git.v4"
+)
+
+func uploadLog(logPath string, id string) {
+	// Upload the log to chief
+	cmdStr := "curl -v -F 'uploadFile=@" + logPath + "' '"
+	cmdStr += irgshConfig.Chief.Address + "/api/v1/log-upload?id=" + id + "&type=build'"
+	err := systemutil.CmdExec(
+		cmdStr,
+		"Uploading log file to chief",
+		"",
+	)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}
+
+// Main task wrapper
+func Build(payload string) (next string, err error) {
+	in := []byte(payload)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+
+	fmt.Println("Processing pipeline :" + raw["taskUUID"].(string))
+
+	logPath := irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string) + "/build.log"
+	go systemutil.StreamLog(logPath)
+
+	next, err = Clone(payload)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		uploadLog(logPath, raw["taskUUID"].(string))
+		return
+	}
+
+	next, err = BuildPreparation(payload)
+	if err != nil {
+		uploadLog(logPath, raw["taskUUID"].(string))
+		return
+	}
+
+	next, err = BuildPackage(payload)
+	if err != nil {
+		uploadLog(logPath, raw["taskUUID"].(string))
+		return
+	}
+
+	next, err = StorePackage(payload)
+
+	if err != nil {
+		uploadLog(logPath, raw["taskUUID"].(string))
+		return
+	}
+
+	uploadLog(logPath, raw["taskUUID"].(string))
+
+	fmt.Println("Done.")
+
+	return
+}
+
+func Clone(payload string) (next string, err error) {
+	in := []byte(payload)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+
+	// Cloning source files
+	sourceURL := raw["sourceUrl"].(string)
+	_, err = git.PlainClone(
+		irgshConfig.Builder.Workdir+"/"+raw["taskUUID"].(string)+"/source",
+		false,
+		&git.CloneOptions{
+			URL:      sourceURL,
+			Progress: os.Stdout,
+		},
+	)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	// Cloning Debian package files
+	packageURL := raw["packageUrl"].(string)
+	_, err = git.PlainClone(
+		irgshConfig.Builder.Workdir+"/"+raw["taskUUID"].(string)+"/package",
+		false,
+		&git.CloneOptions{
+			URL:      packageURL,
+			Progress: os.Stdout,
+		},
+	)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	time.Sleep(0 * time.Second)
+
+	next = payload
+	return
+}
+
+func BuildPreparation(payload string) (next string, err error) {
+	in := []byte(payload)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+
+	tarballB64 := raw["tarball"].(string)
+
+	buff, err := base64.StdEncoding.DecodeString(tarballB64)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return
+	}
+
+	err = ioutil.WriteFile(
+		irgshConfig.Builder.Workdir+"/"+raw["taskUUID"].(string)+"/debuild.tar.gz",
+		buff,
+		07440,
+	)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return
+	}
+
+	// Extract signed DSC
+	cmdStr := "cd " + irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string)
+	cmdStr += " && tar -xvf debuild.tar.gz && rm -f debuild.tar.gz"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"",
+		"",
+	)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return
+	}
+
+	next = payload
+	return
+}
+
+func BuildPackage(payload string) (next string, err error) {
+	in := []byte(payload)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+
+	logPath := irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string) + "/build.log"
+
+	// Copy the source files
+	cmdStr := "cp -vR " + irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string)
+	cmdStr += "/source/* " + irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string)
+	cmdStr += "/package/"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"",
+		logPath,
+	)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return
+	}
+
+	// Cleanup pbuilder cache result
+	_ = systemutil.CmdExec(
+		"rm -rf /var/cache/pbuilder/result/*",
+		"",
+		"",
+	)
+
+	// Building the package
+	cmdStr = "docker run -v " + irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string)
+	cmdStr += ":/tmp/build --privileged=true -i pbocker bash -c /build.sh"
+	fmt.Println(cmdStr)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Building the package",
+		logPath,
+	)
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+
+	next = payload
+	return
+}
+
+func StorePackage(payload string) (next string, err error) {
+	in := []byte(payload)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+
+	logPath := irgshConfig.Builder.Workdir + "/" + raw["taskUUID"].(string) + "/build.log"
+
+	cmdStr := "cd " + irgshConfig.Builder.Workdir + " && "
+	cmdStr += "tar -zcvf " + raw["taskUUID"].(string) + ".tar.gz " + raw["taskUUID"].(string)
+	cmdStr += " && curl -v -F 'uploadFile=@" + irgshConfig.Builder.Workdir
+	cmdStr += "/" + raw["taskUUID"].(string) + ".tar.gz' "
+	cmdStr += irgshConfig.Chief.Address + "/api/v1/artifact-upload?id="
+	cmdStr += raw["taskUUID"].(string)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"",
+		logPath,
+	)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return
+	}
+
+	next = payload
+	return
+}

--- a/cmd/builder/builder_test.go
+++ b/cmd/builder/builder_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/blankon/irgsh-go/internal/config"
+	"github.com/ghodss/yaml"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	validator "gopkg.in/go-playground/validator.v9"
+)
+
+func TestBuilderPreparation(t *testing.T) {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	configPath = "../utils/config.yml"
+	irgshConfig = config.IrgshConfig{}
+	yamlFile, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	err = yaml.Unmarshal(yamlFile, &irgshConfig)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	validate := validator.New()
+	err = validate.Struct(irgshConfig.Builder)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	dir, _ := os.Getwd()
+	irgshConfig.Builder.Workdir = dir + "/../tmp"
+}
+
+func TestBuilderClone(t *testing.T) {
+	id := time.Now().Format("2006-01-02-150405") + "_" + uuid.New().String()
+	log.Println(id)
+	payload := "{\"taskUUID\":\"" + id + "\",\"timestamp\":\"2019-04-03T07:23:02.826753827-04:00\",\"sourceUrl\":\"https://github.com/BlankOn/bromo-theme.git\",\"packageUrl\":\"https://github.com/BlankOn-packages/bromo-theme.git\"}"
+	_, err := Clone(payload)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+
+	cmdStr := "du -s " + irgshConfig.Builder.Workdir + "/" + id + "/source | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd := exec.Command("bash", "-c", cmdStr)
+	out, _ := cmd.CombinedOutput()
+	cmd.Run()
+	log.Println(string(out))
+	size, err := strconv.Atoi(string(out))
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	assert.NotEqual(t, size, int(0))
+
+	cmdStr = "du -s " + irgshConfig.Builder.Workdir + "/" + id + "/package | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd = exec.Command("bash", "-c", cmdStr)
+	out, _ = cmd.CombinedOutput()
+	cmd.Run()
+	size, err = strconv.Atoi(string(out))
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	assert.NotEqual(t, size, int(0))
+}
+
+func TestBuilderCloneInvalidSourceUrl(t *testing.T) {
+	id := time.Now().Format("2006-01-02-150405") + "_" + uuid.New().String()
+	log.Println(id)
+	payload := "{\"taskUUID\":\"" + id + "\",\"timestamp\":\"2019-04-03T07:23:02.826753827-04:00\",\"sourceUrl\":\"https://github.com/BlankOn/bromo-theme-xyz.git\",\"packageUrl\":\"https://github.com/BlankOn-packages/bromo-theme.git\"}"
+	_, err := Clone(payload)
+	assert.Equal(t, err != nil, true, "Should be error")
+
+	cmdStr := "du -s " + irgshConfig.Builder.Workdir + "/" + id + "/source | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd := exec.Command("bash", "-c", cmdStr)
+	out, _ := cmd.CombinedOutput()
+	cmd.Run()
+	size, err := strconv.Atoi(string(out))
+	assert.Equal(t, err != nil, true, "Should be error")
+	assert.Equal(t, size, int(0))
+
+	cmdStr = "du -s " + irgshConfig.Builder.Workdir + "/" + id + "/package | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd = exec.Command("bash", "-c", cmdStr)
+	out, _ = cmd.CombinedOutput()
+	cmd.Run()
+	size, err = strconv.Atoi(string(out))
+	assert.Equal(t, err != nil, true, "Should be error")
+	assert.Equal(t, size, int(0))
+}
+
+func TestBuilderCloneInvalidPackadeUrl(t *testing.T) {
+	id := time.Now().Format("2006-01-02-150405") + "_" + uuid.New().String()
+	log.Println(id)
+	payload := "{\"taskUUID\":\"" + id + "\",\"timestamp\":\"2019-04-03T07:23:02.826753827-04:00\",\"sourceUrl\":\"https://github.com/BlankOn/bromo-theme.git\",\"packageUrl\":\"https://github.com/BlankOn-packages/bromo-theme-xyz.git\"}"
+	_, err := Clone(payload)
+	assert.Equal(t, err != nil, true, "Should be error")
+
+	cmdStr := "du -s " + irgshConfig.Builder.Workdir + "/" + id + "/source | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd := exec.Command("bash", "-c", cmdStr)
+	out, _ := cmd.CombinedOutput()
+	cmd.Run()
+	size, err := strconv.Atoi(string(out))
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	assert.NotEqual(t, size, int(0))
+
+	cmdStr = "du -s " + irgshConfig.Builder.Workdir + "/" + id + "/package | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd = exec.Command("bash", "-c", cmdStr)
+	out, _ = cmd.CombinedOutput()
+	cmd.Run()
+	size, err = strconv.Atoi(string(out))
+	assert.Equal(t, err != nil, true, "Should be error")
+	assert.Equal(t, size, int(0))
+}
+
+// This tests below need pbuilder/sudo
+
+func TestBuilderBuildPreparation(t *testing.T) {
+	t.Skip()
+}
+
+func TestBuilderBuildPackage(t *testing.T) {
+	t.Skip()
+}
+
+func TestBuilderStorePackage(t *testing.T) {
+	t.Skip()
+}

--- a/cmd/builder/init.go
+++ b/cmd/builder/init.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blankon/irgsh-go/pkg/systemutil"
+	"github.com/google/uuid"
+	"github.com/manifoldco/promptui"
+)
+
+func InitBase() (err error) {
+	// TODO base.tgz file name should be based on distribution code name
+	fmt.Println("WARNING: This subcommand need to be run under root or sudo.")
+	prompt := promptui.Prompt{
+		Label:     "irgsh-builder init-base will create (or recreate if already exists) the pbuilder base.tgz on your system and may took long time to be complete. Are you sure?",
+		IsConfirm: true,
+	}
+	result, promptErr := prompt.Run()
+	// Avoid shadowed err
+	err = promptErr
+	if err != nil {
+		return
+	}
+	if strings.ToLower(result) != "y" {
+		return
+	}
+	logPath := irgshConfig.Builder.Workdir
+	logPath += "/irgsh-builder-init-base-" + uuid.New().String() + ".log"
+	go systemutil.StreamLog(logPath)
+
+	fmt.Println("Installing and preparing pbuilder and friends...")
+
+	cmdStr := "apt-get update && apt-get install -y pbuilder debootstrap devscripts equivs"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Preparing pbuilder and it's dependencies",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = "rm /var/cache/pbuilder/base*"
+	_ = systemutil.CmdExec(
+		cmdStr,
+		"",
+		logPath,
+	)
+
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+	cmdStr = "pbuilder create --debootstrapopts --variant=buildd"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Creating pbuilder base.tgz",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = "pbuilder update"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Updating base.tgz",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = "chmod a+rw /var/cache/pbuilder/base*"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Updating base.tgz",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	fmt.Println("Done.")
+
+	return
+}
+
+func UpdateBase() (err error) {
+	fmt.Println("WARNING: This subcommand need to be run under root or sudo.")
+	logPath := "/tmp/irgsh-builder-update-base-" + uuid.New().String() + ".log"
+	go systemutil.StreamLog(logPath)
+
+	fmt.Println("Updating base.tgz...")
+	cmdStr := "sudo pbuilder update"
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Updating base.tgz",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	fmt.Println("Done.")
+
+	return
+}
+
+func InitBuilder() (err error) {
+	logPath := irgshConfig.Builder.Workdir
+	logPath += "/irgsh-builder-init-" + uuid.New().String() + ".log"
+	go systemutil.StreamLog(logPath)
+
+	fmt.Println("Preparing containerized pbuilder...")
+
+	cmdStr := `mkdir -p ` + irgshConfig.Builder.Workdir + `/pbocker && \
+    cp /var/cache/pbuilder/base.tgz ` + irgshConfig.Builder.Workdir + `/pbocker/base.tgz`
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Copying base.tgz",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = `echo 'FROM debian:latest' > ` + irgshConfig.Builder.Workdir + `/pbocker/Dockerfile && \
+    echo 'RUN apt-get update && apt-get -y install pbuilder' >> ` + irgshConfig.Builder.Workdir + `/pbocker/Dockerfile && \
+    echo 'RUN echo "MIRRORSITE=` + irgshConfig.Builder.UpstreamDistUrl + `" > /root/.pbuilderrc' >> ` + irgshConfig.Builder.Workdir + `/pbocker/Dockerfile && \
+    echo 'RUN echo "USENETWORK=yes"' >> ` + irgshConfig.Builder.Workdir + `/pbocker/Dockerfile && \
+    echo 'COPY base.tgz /var/cache/pbuilder/' >> ` + irgshConfig.Builder.Workdir + `/pbocker/Dockerfile && \
+    echo 'RUN echo "pbuilder --build /tmp/build/*.dsc && cp -vR /var/cache/pbuilder/result/* /tmp/build/" > /build.sh && chmod a+x /build.sh' >> ` + irgshConfig.Builder.Workdir + `/pbocker/Dockerfile`
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Preparing Dockerfile",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = `cd ` + irgshConfig.Builder.Workdir +
+		`/pbocker && docker build --no-cache -t pbocker .`
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Building pbocker docker image",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	fmt.Println("Done.")
+
+	return
+}

--- a/cmd/builder/init_test.go
+++ b/cmd/builder/init_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	validator "gopkg.in/go-playground/validator.v9"
+
+	"github.com/blankon/irgsh-go/internal/config"
+)
+
+func TestBasePreparation(t *testing.T) {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	configPath = "../utils/config.yml"
+	irgshConfig = config.IrgshConfig{}
+	yamlFile, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	err = yaml.Unmarshal(yamlFile, &irgshConfig)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	validate := validator.New()
+	err = validate.Struct(irgshConfig.Builder)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	dir, _ := os.Getwd()
+	irgshConfig.Builder.Workdir = dir + "/../tmp"
+}
+
+func TestBaseInitBase(t *testing.T) {
+	t.Skip() // This still need sudo
+	err := InitBase()
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+
+	cmdStr := "du -s /var/cache/pbuilder/base.tgz | "
+	cmdStr += "cut -d '/' -f1 | head -n 1 | sed 's/ //g' | "
+	cmdStr += "tr -d '\n' | tr -d '\t' "
+	cmd := exec.Command("bash", "-c", cmdStr)
+	out, _ := cmd.CombinedOutput()
+	cmd.Run()
+	size, err := strconv.Atoi(string(out))
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	assert.NotEqual(t, size, int(0))
+}

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	machinery "github.com/RichardKnop/machinery/v1"
+	machineryConfig "github.com/RichardKnop/machinery/v1/config"
+	"github.com/urfave/cli"
+
+	"github.com/blankon/irgsh-go/internal/config"
+)
+
+var (
+	app        *cli.App
+	configPath string
+	server     *machinery.Server
+
+	irgshConfig = config.IrgshConfig{}
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	irgshConfig, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalln("couldn't load config : ", err)
+	}
+
+	_ = exec.Command("bash", "-c", "mkdir -p "+irgshConfig.Builder.Workdir)
+
+	app = cli.NewApp()
+	app.Name = "irgsh-go"
+	app.Usage = "irgsh-go distributed packager"
+	app.Author = "BlankOn Developer"
+	app.Email = "blankon-dev@googlegroups.com"
+	app.Version = "IRGSH_GO_VERSION"
+
+	app.Commands = []cli.Command{
+		{
+			Name:    "init-builder",
+			Aliases: []string{"i"},
+			Usage:   "Initialize builder",
+			Action: func(c *cli.Context) error {
+				err := InitBuilder()
+				return err
+			},
+		},
+		{
+			Name:    "init-base",
+			Aliases: []string{"i"},
+			Usage:   "Initialize pbuilder base.tgz. This need to be run under sudo or root",
+			Action: func(c *cli.Context) error {
+				err := InitBase()
+				return err
+			},
+		},
+		{
+			Name:    "update-base",
+			Aliases: []string{"i"},
+			Usage:   "update base.tgz",
+			Action: func(c *cli.Context) error {
+				err := UpdateBase()
+				return err
+			},
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+
+		go serve()
+
+		server, err = machinery.NewServer(
+			&machineryConfig.Config{
+				Broker:        irgshConfig.Redis,
+				ResultBackend: irgshConfig.Redis,
+				DefaultQueue:  "irgsh",
+			},
+		)
+		if err != nil {
+			fmt.Println("Could not create server : " + err.Error())
+		}
+
+		server.RegisterTask("build", Build)
+
+		worker := server.NewWorker("builder", 1)
+		err = worker.Launch()
+		if err != nil {
+			fmt.Println("Could not launch worker : " + err.Error())
+		}
+
+		return nil
+
+	}
+	app.Run(os.Args)
+}
+
+func serve() {
+	fs := http.FileServer(http.Dir(irgshConfig.Builder.Workdir))
+	http.Handle("/", fs)
+	log.Println("irgsh-go builder now live on port 8081, serving path : " + irgshConfig.Builder.Workdir)
+	log.Fatal(http.ListenAndServe(":8081", nil))
+}

--- a/cmd/iso/main.go
+++ b/cmd/iso/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	machinery "github.com/RichardKnop/machinery/v1"
+	machineryConfig "github.com/RichardKnop/machinery/v1/config"
+	"github.com/blankon/irgsh-go/internal/config"
+	"github.com/urfave/cli"
+)
+
+var (
+	app        *cli.App
+	configPath string
+	server     *machinery.Server
+
+	irgshConfig = config.IrgshConfig{}
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	irgshConfig, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalln("couldn't load config : ", err)
+	}
+
+	_ = exec.Command("bash", "-c", "mkdir -p "+irgshConfig.ISO.Workdir)
+
+	app = cli.NewApp()
+	app.Name = "irgsh-go"
+	app.Usage = "irgsh-go distributed packager"
+	app.Author = "BlankOn Developer"
+	app.Email = "blankon-dev@googlegroups.com"
+	app.Version = "IRGSH_GO_VERSION"
+
+	app.Commands = []cli.Command{
+		{
+			Name:    "init",
+			Aliases: []string{"i"},
+			Usage:   "initialize iso",
+			Action: func(c *cli.Context) error {
+				// Do nothing
+				return nil
+			},
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+
+		go serve()
+
+		server, err = machinery.NewServer(
+			&machineryConfig.Config{
+				Broker:        irgshConfig.Redis,
+				ResultBackend: irgshConfig.Redis,
+				DefaultQueue:  "irgsh",
+			},
+		)
+		if err != nil {
+			fmt.Println("Could not create server : " + err.Error())
+		}
+
+		server.RegisterTask("iso", BuildISO)
+
+		worker := server.NewWorker("iso", 2)
+		err = worker.Launch()
+		if err != nil {
+			fmt.Println("Could not launch worker : " + err.Error())
+		}
+
+		return nil
+
+	}
+	app.Run(os.Args)
+}
+
+func serve() {
+	fs := http.FileServer(http.Dir(irgshConfig.ISO.Workdir))
+	http.Handle("/", fs)
+	log.Println("irgsh-go iso now live on port 8083, serving path : " + irgshConfig.ISO.Workdir)
+	log.Fatal(http.ListenAndServe(":8083", nil))
+}
+
+func BuildISO(payload string) (next string, err error) {
+	fmt.Println("Done")
+	return
+}

--- a/cmd/repo/main.go
+++ b/cmd/repo/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -10,9 +9,7 @@ import (
 
 	machinery "github.com/RichardKnop/machinery/v1"
 	machineryConfig "github.com/RichardKnop/machinery/v1/config"
-	"github.com/ghodss/yaml"
 	"github.com/urfave/cli"
-	validator "gopkg.in/go-playground/validator.v9"
 
 	"github.com/blankon/irgsh-go/internal/config"
 )
@@ -22,34 +19,17 @@ var (
 	configPath string
 	server     *machinery.Server
 
-	irgshConfig config.IrgshConfig
+	irgshConfig = config.IrgshConfig{}
 )
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	// Load config
-	configPath = os.Getenv("IRGSH_CONFIG_PATH")
-	if len(configPath) == 0 {
-		configPath = "/etc/irgsh/config.yml"
-	}
-	irgshConfig = config.IrgshConfig{}
-	yamlFile, err := ioutil.ReadFile(configPath)
+	irgshConfig, err := config.LoadConfig()
 	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
+		log.Fatalln("couldn't load config : ", err)
 	}
-	err = yaml.Unmarshal(yamlFile, &irgshConfig)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
-	validate := validator.New()
-	err = validate.Struct(irgshConfig.Repo)
-	if err != nil {
-		log.Fatal(err.Error())
-		os.Exit(1)
-	}
+
 	_ = exec.Command("bash", "-c", "mkdir -p "+irgshConfig.Repo.Workdir)
 
 	app = cli.NewApp()

--- a/cmd/repo/repo.go
+++ b/cmd/repo/repo.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/blankon/irgsh-go/pkg/systemutil"
+	"github.com/manifoldco/promptui"
+)
+
+func uploadLog(logPath string, id string) {
+	// Upload the log to chief
+	cmdStr := "curl -v -F 'uploadFile=@" + logPath + "' '" + irgshConfig.Chief.Address + "/api/v1/log-upload?id=" + id + "&type=repo'"
+	fmt.Println(cmdStr)
+	err := systemutil.CmdExec(
+		cmdStr,
+		"Uploading log file to chief",
+		"",
+	)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}
+
+// Main task wrapper
+func Repo(payload string) (err error) {
+	fmt.Println("##### Submitting the package into the repository")
+	in := []byte(payload)
+	var raw map[string]interface{}
+	json.Unmarshal(in, &raw)
+
+	experimentalSuffix := "-experimental"
+	if !raw["isExperimental"].(bool) {
+		experimentalSuffix = ""
+	}
+
+	logPath := irgshConfig.Repo.Workdir + "/artifacts/"
+	logPath += raw["taskUUID"].(string) + "/repo.log"
+	go systemutil.StreamLog(logPath)
+
+	cmdStr := fmt.Sprintf(`mkdir -p %s/artifacts && \
+	cd %s/artifacts/ && \
+	wget %s/artifacts/%s.tar.gz && \
+	tar -xvf %s.tar.gz`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Chief.Address,
+		raw["taskUUID"].(string),
+		raw["taskUUID"].(string),
+	)
+	err = systemutil.CmdExec(cmdStr, "Downloading the artifact", logPath)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		uploadLog(logPath, raw["taskUUID"].(string))
+		return
+	}
+
+	if raw["isExperimental"].(bool) {
+		// Ignore version conflict
+		cmdStr = fmt.Sprintf(`cd %s/%s/ && \
+		GNUPGHOME=/var/lib/irgsh/gnupg reprepro -v -v -v --nothingiserror remove %s \
+		$(cat %s/artifacts/%s/*.dsc | grep 'Source:' | cut -d ' ' -f 2)`,
+			irgshConfig.Repo.Workdir,
+			irgshConfig.Repo.DistCodename+experimentalSuffix,
+			irgshConfig.Repo.DistCodename+experimentalSuffix,
+			irgshConfig.Repo.Workdir,
+			raw["taskUUID"],
+		)
+		err = systemutil.CmdExec(
+			cmdStr,
+			"This is experimental package, remove any existing package.",
+			logPath,
+		)
+		if err != nil {
+			// Ignore err
+			fmt.Printf("error: %v\n", err)
+		}
+	}
+
+	cmdStr = fmt.Sprintf(`cd %s/%s/ && \
+	GNUPGHOME=/var/lib/irgsh/gnupg reprepro -v -v -v --nothingiserror includedeb %s %s/artifacts/%s/*.deb`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+experimentalSuffix,
+		irgshConfig.Repo.DistCodename+experimentalSuffix,
+		irgshConfig.Repo.Workdir,
+		raw["taskUUID"],
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Injecting the deb files from artifact to the repository",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		uploadLog(logPath, raw["taskUUID"].(string))
+		return
+	}
+
+	uploadLog(logPath, raw["taskUUID"].(string))
+	fmt.Println("[ BUILD DONE ]")
+	return
+}
+
+func InitRepo() (err error) {
+	prompt := promptui.Prompt{
+		Label:     "Are you sure you want to initialize new repository? Any existing distribution will be flushed.",
+		IsConfirm: true,
+	}
+	result, err := prompt.Run()
+	if err != nil {
+		return
+	}
+	if strings.ToLower(result) != "y" {
+		return
+	}
+
+	// TODO ask for matched distribution name as this command is super dangerous
+
+	fmt.Println("##### Initializing new repository for " + irgshConfig.Repo.DistCodename)
+
+	logPath := irgshConfig.Repo.Workdir + "/init.log"
+	go systemutil.StreamLog(logPath)
+
+	repoTemplatePath := "/usr/share/irgsh/reprepro-template"
+	if irgshConfig.IsTest {
+		dir, _ := os.Getwd()
+		repoTemplatePath = dir + "/../utils/reprepro-template"
+	}
+	cmdStr := fmt.Sprintf("mkdir -p %s && rm -rf %s/%s; cp -vR %s %s/%s",
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+		repoTemplatePath,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+	)
+	err = systemutil.CmdExec(cmdStr, "Preparing reprepro template", logPath)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = fmt.Sprintf(`cd %s/%s/conf && cat updates.orig | 
+		sed 's/UPSTREAM_NAME/%s/g' | 
+		sed 's/UPSTREAM_DIST_CODENAME/%s/g' | 
+		sed 's/UPSTREAM_DIST_URL/%s/g' | 
+		sed 's/DIST_SUPPORTED_ARCHITECTURES/%s/g' | 
+		sed 's/UPSTREAM_DIST_COMPONENTS/%s/g' > updates && rm updates.orig`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+		irgshConfig.Repo.UpstreamName,
+		irgshConfig.Repo.UpstreamDistCodename,
+		strings.Replace(irgshConfig.Repo.UpstreamDistUrl, "/", "\\/", -1),
+		irgshConfig.Repo.DistSupportedArchitectures,
+		irgshConfig.Repo.UpstreamDistComponents,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Populate the reprepro's updates config file with values from irgsh's config.yml",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = fmt.Sprintf(`cd %s/%s/conf && cat distributions.orig |
+		sed 's/DIST_NAME/%s/g' |
+		sed 's/DIST_LABEL/%s/g' |
+		sed 's/DIST_CODENAME/%s/g' |
+		sed 's/DIST_COMPONENTS/%s/g' |
+		sed 's/DIST_SUPPORTED_ARCHITECTURES/%s/g' |
+		sed 's/DIST_VERSION_DESC/%s/g' |
+		sed 's/DIST_VERSION/%s/g' |
+		sed 's/DIST_SIGNING_KEY/%s/g' |
+		sed 's/UPSTREAM_NAME/%s/g'> distributions && rm distributions.orig`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+		irgshConfig.Repo.DistName,
+		irgshConfig.Repo.DistLabel,
+		irgshConfig.Repo.DistCodename,
+		irgshConfig.Repo.DistComponents,
+		irgshConfig.Repo.DistSupportedArchitectures,
+		irgshConfig.Repo.DistVersionDesc,
+		irgshConfig.Repo.DistVersion,
+		irgshConfig.Repo.DistSigningKey,
+		irgshConfig.Repo.UpstreamName,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Populate the reprepro's distributions config file with values from irgsh's config.yml",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	repositoryPath := strings.Replace(
+		irgshConfig.Repo.Workdir+"/"+irgshConfig.Repo.DistCodename,
+		"/",
+		"\\/",
+		-1,
+	)
+	cmdStr = fmt.Sprintf(`cd %s/%s/conf && \
+	cat options.orig | sed 's/IRGSH_REPO_WORKDIR/%s/g' > options && \
+	rm options.orig`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+		repositoryPath,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Populate the reprepro's options config file with values from irgsh's config.yml",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = fmt.Sprintf("cd %s/%s/ && reprepro -v -v -v export",
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Initialize the reprepro repository for the first time",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	fmt.Println("##### Initializing the experimental repository for " + irgshConfig.Repo.DistCodename)
+	// With -experimental suffix
+
+	cmdStr = fmt.Sprintf("mkdir -p %s && rm -rf %s/%s; cp -vR %s %s/%s",
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+"-experimental",
+		repoTemplatePath,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+"-experimental",
+	)
+	err = systemutil.CmdExec(cmdStr, "Preparing reprepro template", logPath)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = fmt.Sprintf(`cd %s/%s/conf && cat updates.orig | 
+		sed 's/UPSTREAM_NAME/%s/g' | 
+		sed 's/UPSTREAM_DIST_CODENAME/%s/g' | 
+		sed 's/UPSTREAM_DIST_URL/%s/g' | 
+		sed 's/DIST_SUPPORTED_ARCHITECTURES/%s/g' | 
+		sed 's/UPSTREAM_DIST_COMPONENTS/%s/g' > updates && rm updates.orig`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+"-experimental",
+		irgshConfig.Repo.UpstreamName,
+		irgshConfig.Repo.UpstreamDistCodename+"-experimental",
+		strings.Replace(irgshConfig.Repo.UpstreamDistUrl, "/", "\\/", -1),
+		irgshConfig.Repo.DistSupportedArchitectures,
+		irgshConfig.Repo.UpstreamDistComponents,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Populate the reprepro's updates config file with values from irgsh's config.yml",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = fmt.Sprintf(`cd %s/%s/conf && cat distributions.orig |
+		sed 's/DIST_NAME/%s/g' |
+		sed 's/DIST_LABEL/%s/g' |
+		sed 's/DIST_CODENAME/%s/g' |
+		sed 's/DIST_COMPONENTS/%s/g' |
+		sed 's/DIST_SUPPORTED_ARCHITECTURES/%s/g' |
+		sed 's/DIST_VERSION_DESC/%s/g' |
+		sed 's/DIST_VERSION/%s/g' |
+		sed 's/DIST_SIGNING_KEY/%s/g' |
+		sed 's/UPSTREAM_NAME/%s/g'> distributions && rm distributions.orig`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+"-experimental",
+		irgshConfig.Repo.DistName,
+		irgshConfig.Repo.DistLabel,
+		irgshConfig.Repo.DistCodename+"-experimental",
+		irgshConfig.Repo.DistComponents,
+		irgshConfig.Repo.DistSupportedArchitectures,
+		irgshConfig.Repo.DistVersionDesc,
+		irgshConfig.Repo.DistVersion,
+		irgshConfig.Repo.DistSigningKey,
+		irgshConfig.Repo.UpstreamName,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Populate the reprepro's distributions config file with values from irgsh's config.yml",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	repositoryPath = strings.Replace(
+		irgshConfig.Repo.Workdir+"/"+irgshConfig.Repo.DistCodename+"-experimental",
+		"/",
+		"\\/",
+		-1,
+	)
+	cmdStr = fmt.Sprintf(`cd %s/%s/conf && \
+	cat options.orig | sed 's/IRGSH_REPO_WORKDIR/%s/g' > options && \
+	rm options.orig`,
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+"-experimental",
+		repositoryPath,
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Populate the reprepro's options config file with values from irgsh's config.yml",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	cmdStr = fmt.Sprintf("cd %s/%s/ && reprepro -v -v -v export",
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename+"-experimental",
+	)
+	err = systemutil.CmdExec(
+		cmdStr,
+		"Initialize the reprepro repository for the first time",
+		logPath,
+	)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	return
+}
+
+func UpdateRepo() (err error) {
+	fmt.Printf("Syncing irgshConfig.Repo.against %s at %s...",
+		irgshConfig.Repo.UpstreamDistCodename,
+		irgshConfig.Repo.UpstreamDistUrl,
+	)
+
+	logPath := irgshConfig.Repo.Workdir + "/update.log"
+	go systemutil.StreamLog(logPath)
+
+	cmdStr := fmt.Sprintf("cd %s/%s/ && reprepro -v -v -v update > %s",
+		irgshConfig.Repo.Workdir,
+		irgshConfig.Repo.DistCodename,
+		logPath,
+	)
+	err = systemutil.CmdExec(cmdStr, "Sync the repository against upstream repository", logPath)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		return
+	}
+
+	return
+}

--- a/cmd/repo/repo_test.go
+++ b/cmd/repo/repo_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/blankon/irgsh-go/internal/config"
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	validator "gopkg.in/go-playground/validator.v9"
+)
+
+func TestRepoPreparation(t *testing.T) {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	configPath = "../utils/config.yml"
+	irgshConfig = config.IrgshConfig{}
+	yamlFile, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	err = yaml.Unmarshal(yamlFile, &irgshConfig)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	validate := validator.New()
+	err = validate.Struct(irgshConfig.Repo)
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	dir, _ := os.Getwd()
+	irgshConfig.Repo.Workdir = dir + "/../tmp"
+	irgshConfig.IsTest = true
+}
+
+func TestBaseInitRepo(t *testing.T) {
+	err := InitRepo()
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+
+	cmdStr := "du -s " + irgshConfig.Repo.Workdir + "/verbeek | cut -d '/' -f1 | head -n 1 | sed 's/ //g' | tr -d '\n' | tr -d '\t' "
+	cmd := exec.Command("bash", "-c", cmdStr)
+	out, _ := cmd.CombinedOutput()
+	cmd.Run()
+	size, err := strconv.Atoi(string(out))
+	if err != nil {
+		log.Println(err.Error())
+		assert.Equal(t, true, false, "Should not reach here")
+	}
+	assert.NotEqual(t, size, int(0))
+}
+
+func TestBaseInitRepoConfigCheck(t *testing.T) {
+	t.Skip()
+}

--- a/pkg/systemutil/util.go
+++ b/pkg/systemutil/util.go
@@ -1,0 +1,58 @@
+package systemutil
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/hpcloud/tail"
+)
+
+// CmdExec run os command
+func CmdExec(cmdStr string, cmdDesc string, logPath string) (err error) {
+	if len(cmdStr) == 0 {
+		return errors.New("No command string provided.")
+	}
+
+	if len(logPath) > 0 {
+
+		logPathArr := strings.Split(logPath, "/")
+		logPathArr = logPathArr[:len(logPathArr)-1]
+		logDir := "/" + strings.Join(logPathArr, "/")
+		os.MkdirAll(logDir, os.ModePerm)
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, _ = f.WriteString("\n")
+		if len(cmdDesc) > 0 {
+			cmdDescSplitted := strings.Split(cmdDesc, "\n")
+			for _, desc := range cmdDescSplitted {
+				_, _ = f.WriteString("##### " + desc + "\n")
+			}
+		}
+		_, _ = f.WriteString("##### RUN " + cmdStr + "\n")
+		f.Close()
+		cmdStr += " 2>&1 | tee -a " + logPath
+	}
+	// `set -o pipefail` will forces to return the original exit code
+	cmd := exec.Command("bash", "-c", "set -o pipefail && "+cmdStr)
+	err = cmd.Run()
+
+	return
+}
+
+// StreamLog tailing a file
+func StreamLog(path string) {
+	t, err := tail.TailFile(path, tail.Config{Follow: true})
+	if err != nil {
+		log.Printf("error: %v\n", err)
+	}
+	for line := range t.Lines {
+		fmt.Println(line.Text)
+	}
+}


### PR DESCRIPTION
Move all apps to cmd 
This will also remove the need of copying util files to each app directory to address #61 

Refactor config loading
Unifying config loading function
The config loading function will try several path to make running development build easier