### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -1,75 +1,81 @@
-name: generic
+name: Generic github actions
 
 on:
   push:
-    branches:
-      - '!master'
+    branches-ignore:
+      - 'master'
   pull_request:
     branches:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   build-devel:
     runs-on: ubuntu-latest
-
     steps:
     - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(TZ='Asia/Jakarta' date +'%Y%m%d%H%M')"
-    - uses: actions/checkout@v1
-    - name: Build Development release
+      run: echo "irgsh_build_date=$(TZ='Asia/Jakarta' date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
+    - name: Install needed apt packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.2.3
+      with:
+        packages: gpg pbuilder debootstrap devscripts python3-apt reprepro make
+        version: 1.0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.13.14'
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build development release
       run: |
-        sudo apt update && sudo apt install -y gpg pbuilder debootstrap devscripts python-apt reprepro make
-        curl -O https://storage.googleapis.com/golang/go1.13.14.linux-amd64.tar.gz
-        tar -xf go1.13.14.linux-amd64.tar.gz
-        sudo mv go /usr/local
-        echo ${{ steps.date.outputs.date }}-development-build > VERSION
+        echo ${{ env.irgsh_build_date }}-development-build > VERSION
         make release
         mv target/{release,pre-release}.tar.gz
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v3
       with:
         name: pre-release.tar.gz
         path: target/
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      with:
-        tag_name: ${{ steps.date.outputs.date }}
-        release_name: ${{ steps.date.outputs.date }} Development Release
-        body: |
-          Development release ${{ steps.date.outputs.date }}
-        draft: false
-        prerelease: true
-    - name: Upload Full Release Asset
-      id: upload-full-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: ./target/pre-release.tar.gz
-        asset_name: pre-release.tar.gz
-        asset_content_type: application/tar+gzip
-    - name: Upload CLI Release
-      id: upload-cli-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./irgsh-go/usr/bin/irgsh-cli
-        asset_name: irgsh-cli
-        asset_content_type: application/x-executable
+    outputs:
+      irgsh_build_date: ${{ env.irgsh_build_date }}
 
-  deploy:
+  release:
     runs-on: ubuntu-latest
     needs: [build-devel]
     steps:
-    - name: Deployment
-      env:
-        HOST: ${{secrets.RAFI_HOSTNAME}}
-        KEY: ${{secrets.RAFI_DEPLOYMENT_KEY}}
+    - uses: actions/download-artifact@v3
+      with:
+        name: pre-release.tar.gz
+    - name: Extract pre-release
       run: |
-        curl --header "Content-Type: application/json" --request POST --data "{\"name\":\"irgsh-dev\",\"token\": \""$KEY"\"}" https://$HOST/tendang
+        tar xvzf pre-release.tar.gz
+        cp $(find . -type f -name "irgsh-cli") .
+    - name: Create github pre-release
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        name: ${{ needs.build-devel.outputs.irgsh_build_date }} Development Release
+        body: Development release ${{ needs.build-devel.outputs.irgsh_build_date }}
+        draft: false
+        prerelease: true
+        tag_name: ${{ needs.build-devel.outputs.irgsh_build_date }}-development-build
+        files: |
+          pre-release.tar.gz
+          irgsh-cli
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+    - name: deploy to irgsh development server
+      uses: kudaliar032/tendang-action@v1
+      with:
+        url: ${{ secrets.RAFI_TENDANG_URL }}
+        token: ${{ secrets.RAFI_DEPLOYMENT_KEY }}
+        name: ${{ secrets.RAFI_DEPLOYMENT_NAME }}

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - 'master'
-  pull_request:
-    branches:
-      - '*'
 
 permissions:
   contents: write
@@ -73,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     steps:
-    - name: deploy to irgsh development server
+    - name: Deploy to irgsh development server
       uses: kudaliar032/tendang-action@v1
       with:
         url: ${{ secrets.RAFI_TENDANG_URL }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,70 +1,77 @@
-name: master
+name: Master github actions
 
 on:
   push:
     branches:
-      - master
+      - 'master'
+
+permissions:
+  contents: write
 
 jobs:
   build-release:
     runs-on: ubuntu-latest
     steps:
     - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(TZ='Asia/Jakarta' date +'%Y%m%d%H%M')"
-    - uses: actions/checkout@v1
-    - name: Run a multi-line script
+      run: echo "irgsh_build_date=$(TZ='Asia/Jakarta' date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
+    - name: Install needed apt packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.2.3
+      with:
+        packages: gpg pbuilder debootstrap devscripts python3-apt reprepro make
+        version: 1.0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.13.14'
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build nightly release
       run: |
-        sudo apt update && sudo apt install -y gpg pbuilder debootstrap devscripts python-apt reprepro make
-        curl -O https://storage.googleapis.com/golang/go1.13.14.linux-amd64.tar.gz
-        tar -xf go1.13.14.linux-amd64.tar.gz
-        sudo mv go /usr/local
         echo ${{ steps.date.outputs.date }}-nightly-build > VERSION
         make release
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v3
       with:
         name: release.tar.gz
         path: target/
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      with:
-        tag_name: ${{ steps.date.outputs.date }}
-        release_name: ${{ steps.date.outputs.date }} Nightly Release
-        body: |
-          Nightly release
-        draft: false
-        prerelease: false
-    - name: Upload Full Release Asset
-      id: upload-full-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: ./target/release.tar.gz
-        asset_name: release.tar.gz
-        asset_content_type: application/tar+gzip
-    - name: Upload CLI Release
-      id: upload-cli-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./irgsh-go/usr/bin/irgsh-cli
-        asset_name: irgsh-cli
-        asset_content_type: application/x-executable
+    outputs:
+      irgsh_build_date: ${{ env.irgsh_build_date }}
 
-  deploy:
+  release:
     runs-on: ubuntu-latest
     needs: [build-release]
     steps:
-    - name: Deployment
-      env:
-        HOST: ${{secrets.RANI_HOSTNAME}}
-        KEY: ${{secrets.RANI_DEPLOYMENT_KEY}}
+    - uses: actions/download-artifact@v3
+      with:
+        name: release.tar.gz
+    - name: Extract release
       run: |
-        curl --header "Content-Type: application/json" --request POST --data "{\"name\":\"irgsh\",\"token\": \""$KEY"\"}" https://$HOST
+        tar xvzf release.tar.gz
+        cp $(find . -type f -name "irgsh-cli") .
+    - name: Create github release
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        name: ${{ needs.build-release.outputs.irgsh_build_date }} Nightly Release
+        body: Nightly release
+        draft: false
+        prerelease: false
+        tag_name: ${{ needs.build-release.outputs.irgsh_build_date }}-nightly-build
+        files: |
+          release.tar.gz
+          irgsh-cli
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+    - name: Deploy to irgsh server
+      uses: kudaliar032/tendang-action@v1
+      with:
+        url: ${{ secrets.RANI_TENDANG_URL }}
+        token: ${{ secrets.RANI_DEPLOYMENT_KEY }}
+        name: ${{ secrets.RANI_DEPLOYMENT_NAME }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,39 @@
+name: Pull request github actions
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build-devel:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get current date
+      run: echo "irgsh_build_date=$(TZ='Asia/Jakarta' date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
+    - name: Install needed apt packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.2.3
+      with:
+        packages: gpg pbuilder debootstrap devscripts python3-apt reprepro make
+        version: 1.0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.13.14'
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Build development release
+      run: |
+        echo ${{ env.irgsh_build_date }}-development-build > VERSION
+        make release
+        mv target/{release,pre-release}.tar.gz
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pre-release.tar.gz
+        path: target/


### PR DESCRIPTION
## Changes

- Change deprecated actions
  - https://github.com/actions/create-release
  - https://github.com/actions/upload-release-asset
  - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Improve caching
- Improve action steps
- Disable release & deploy steps on pull request for security reasons

## Add & Remove Action Secrets

### Add
- `RAFI_DEPLOYMENT_NAME` with value `irgsh-dev`
- `RANI_DEPLOYMENT_NAME` with value `irgsh`
- `RANI_TENDANG_URL` with value `https://tendang.blankonlinux.or.id`
- `RAFI_TENDANG_URL` with value `https://irgsh-dev.blankonlinux.or.id/tendang`

### Remove
- `RAFI_HOSTNAME`
- `RANI_HOSTNAME`

## Related Issues

- #148 