### PR TITLE
e2e: bump Go base image to 1.25

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bookworm AS build
+FROM golang:1.25-bookworm AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- `e2e/Dockerfile` was using `golang:1.23-bookworm` but `go.mod` requires `go 1.25.0`
- With `GOTOOLCHAIN=local`, Go 1.23 refuses to build the module and exits with an error, breaking the nightly e2e run
- Bumped the base image to `golang:1.25-bookworm` to match

Fixes nightly failure: https://github.com/BlankOn/irgsh-go/actions/runs/23986794911/job/69959946707

## Test plan

- [x] Nightly e2e run passes after merge
- [x] `docker build -f e2e/Dockerfile .` completes successfully