### PR TITLE
feat(chief): support sub-path hosting via base_url

### DIFF
--- a/cmd/builder/builder.go
+++ b/cmd/builder/builder.go
@@ -26,15 +26,21 @@ func uploadLog(logPath string, id string) {
 }
 
 func sendBuildNotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
+	logBaseURL := irgshConfig.Chief.PublicURL
+	if logBaseURL == "" {
+		logBaseURL = irgshConfig.Chief.Address
+	}
+	logBaseURL += irgshConfig.Chief.BaseURL
+
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
+		logBaseURL,
 		"Build",
 		taskUUID,
 		status,
 		jobInfo,
 	)
 }
-
 // Main task wrapper
 func Build(payload string) (next string, err error) {
 	in := []byte(payload)

--- a/cmd/builder/builder.go
+++ b/cmd/builder/builder.go
@@ -28,9 +28,8 @@ func uploadLog(logPath string, id string) {
 func sendBuildNotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
 	logBaseURL := irgshConfig.Chief.PublicURL
 	if logBaseURL == "" {
-		logBaseURL = irgshConfig.Chief.Address
+		logBaseURL = irgshConfig.Chief.Address + irgshConfig.Chief.BaseURL
 	}
-	logBaseURL += irgshConfig.Chief.BaseURL
 
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
@@ -41,6 +40,7 @@ func sendBuildNotification(taskUUID, status string, jobInfo notification.JobNoti
 		jobInfo,
 	)
 }
+
 // Main task wrapper
 func Build(payload string) (next string, err error) {
 	in := []byte(payload)

--- a/cmd/builder/builder.go
+++ b/cmd/builder/builder.go
@@ -26,14 +26,9 @@ func uploadLog(logPath string, id string) {
 }
 
 func sendBuildNotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
-	logBaseURL := irgshConfig.Chief.PublicURL
-	if logBaseURL == "" {
-		logBaseURL = irgshConfig.Chief.Address + irgshConfig.Chief.BaseURL
-	}
-
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
-		logBaseURL,
+		irgshConfig.FullBaseURL,
 		"Build",
 		taskUUID,
 		status,

--- a/cmd/chief/main.go
+++ b/cmd/chief/main.go
@@ -163,8 +163,14 @@ func setupRoutes(cfg config.IrgshConfig, artifactEP *artifactEndpoint.ArtifactHT
 	submissionFs := http.FileServer(http.Dir(cfg.Chief.Workdir + "/submissions"))
 	mux.Handle("/submissions/", http.StripPrefix("/submissions/", submissionFs))
 
+	rootMux := http.NewServeMux()
+	if cfg.Chief.BaseURL != "" {
+		rootMux.Handle(cfg.Chief.BaseURL+"/", http.StripPrefix(cfg.Chief.BaseURL, mux))
+	}
+	rootMux.Handle("/", mux)
+
 	return &http.Server{
-		Handler:           mux,
+		Handler:           rootMux,
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       15 * time.Second,
 		IdleTimeout:       90 * time.Second,

--- a/cmd/chief/main.go
+++ b/cmd/chief/main.go
@@ -163,6 +163,8 @@ func setupRoutes(cfg config.IrgshConfig, artifactEP *artifactEndpoint.ArtifactHT
 	submissionFs := http.FileServer(http.Dir(cfg.Chief.Workdir + "/submissions"))
 	mux.Handle("/submissions/", http.StripPrefix("/submissions/", submissionFs))
 
+	// rootMux forwards prefixed browser traffic to mux while also keeping mux
+	// reachable at root so workers can call /api/v1/* without config changes.
 	rootMux := http.NewServeMux()
 	if cfg.Chief.BaseURL != "" {
 		rootMux.Handle(cfg.Chief.BaseURL+"/", http.StripPrefix(cfg.Chief.BaseURL, mux))

--- a/cmd/iso/iso.go
+++ b/cmd/iso/iso.go
@@ -34,15 +34,21 @@ func uploadLog(logPath string, id string) {
 }
 
 func sendISONotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
+	logBaseURL := irgshConfig.Chief.PublicURL
+	if logBaseURL == "" {
+		logBaseURL = irgshConfig.Chief.Address
+	}
+	logBaseURL += irgshConfig.Chief.BaseURL
+
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
+		logBaseURL,
 		"ISO Build",
 		taskUUID,
 		status,
 		jobInfo,
 	)
 }
-
 // BuildISO is the main ISO build task
 func BuildISO(payload string) (next string, err error) {
 	in := []byte(payload)

--- a/cmd/iso/iso.go
+++ b/cmd/iso/iso.go
@@ -34,14 +34,9 @@ func uploadLog(logPath string, id string) {
 }
 
 func sendISONotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
-	logBaseURL := irgshConfig.Chief.PublicURL
-	if logBaseURL == "" {
-		logBaseURL = irgshConfig.Chief.Address + irgshConfig.Chief.BaseURL
-	}
-
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
-		logBaseURL,
+		irgshConfig.FullBaseURL,
 		"ISO Build",
 		taskUUID,
 		status,

--- a/cmd/iso/iso.go
+++ b/cmd/iso/iso.go
@@ -36,9 +36,8 @@ func uploadLog(logPath string, id string) {
 func sendISONotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
 	logBaseURL := irgshConfig.Chief.PublicURL
 	if logBaseURL == "" {
-		logBaseURL = irgshConfig.Chief.Address
+		logBaseURL = irgshConfig.Chief.Address + irgshConfig.Chief.BaseURL
 	}
-	logBaseURL += irgshConfig.Chief.BaseURL
 
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
@@ -49,6 +48,7 @@ func sendISONotification(taskUUID, status string, jobInfo notification.JobNotifi
 		jobInfo,
 	)
 }
+
 // BuildISO is the main ISO build task
 func BuildISO(payload string) (next string, err error) {
 	in := []byte(payload)

--- a/cmd/repo/repo.go
+++ b/cmd/repo/repo.go
@@ -27,15 +27,21 @@ func uploadLog(logPath string, id string) {
 }
 
 func sendRepoNotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
+	logBaseURL := irgshConfig.Chief.PublicURL
+	if logBaseURL == "" {
+		logBaseURL = irgshConfig.Chief.Address
+	}
+	logBaseURL += irgshConfig.Chief.BaseURL
+
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
+		logBaseURL,
 		"Repo",
 		taskUUID,
 		status,
 		jobInfo,
 	)
 }
-
 // Main task wrapper
 func Repo(payload string) (err error) {
 	fmt.Println("##### Submitting the package into the repository")

--- a/cmd/repo/repo.go
+++ b/cmd/repo/repo.go
@@ -27,14 +27,9 @@ func uploadLog(logPath string, id string) {
 }
 
 func sendRepoNotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
-	logBaseURL := irgshConfig.Chief.PublicURL
-	if logBaseURL == "" {
-		logBaseURL = irgshConfig.Chief.Address + irgshConfig.Chief.BaseURL
-	}
-
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
-		logBaseURL,
+		irgshConfig.FullBaseURL,
 		"Repo",
 		taskUUID,
 		status,

--- a/cmd/repo/repo.go
+++ b/cmd/repo/repo.go
@@ -29,9 +29,8 @@ func uploadLog(logPath string, id string) {
 func sendRepoNotification(taskUUID, status string, jobInfo notification.JobNotificationInfo) {
 	logBaseURL := irgshConfig.Chief.PublicURL
 	if logBaseURL == "" {
-		logBaseURL = irgshConfig.Chief.Address
+		logBaseURL = irgshConfig.Chief.Address + irgshConfig.Chief.BaseURL
 	}
-	logBaseURL += irgshConfig.Chief.BaseURL
 
 	notification.SendJobNotification(
 		irgshConfig.Notification.WebhookURL,
@@ -42,6 +41,7 @@ func sendRepoNotification(taskUUID, status string, jobInfo notification.JobNotif
 		jobInfo,
 	)
 }
+
 // Main task wrapper
 func Repo(payload string) (err error) {
 	fmt.Println("##### Submitting the package into the repository")

--- a/internal/chief/usecase/chief.go
+++ b/internal/chief/usecase/chief.go
@@ -33,7 +33,7 @@ func NewChiefUsecase(
 	version string,
 ) (*ChiefUsecase, error) {
 	maintainerSvc := NewMaintainerService(gpg)
-	dashSvc, err := newDashboardSvc(version, taskQueue, maintainerSvc, registry)
+	dashSvc, err := newDashboardSvc(version, cfg.Chief.BaseURL, taskQueue, maintainerSvc, registry)
 	if err != nil {
 		return nil, fmt.Errorf("init dashboard service: %w", err)
 	}
@@ -64,7 +64,7 @@ func newSubmissionSvc(tq TaskQueue, st FileStorage, gpg GPGVerifier, reg *monito
 	return NewSubmissionService(tq, st, gpg, js, is)
 }
 
-func newDashboardSvc(version string, tq TaskQueue, ms *MaintainerService, reg *monitoring.Registry) (*DashboardService, error) {
+func newDashboardSvc(version string, baseURL string, tq TaskQueue, ms *MaintainerService, reg *monitoring.Registry) (*DashboardService, error) {
 	var ir InstanceRegistry
 	var js JobStore
 	var is ISOJobStore
@@ -73,7 +73,7 @@ func newDashboardSvc(version string, tq TaskQueue, ms *MaintainerService, reg *m
 		js = reg
 		is = reg
 	}
-	return NewDashboardService(version, tq, ms, ir, js, is)
+	return NewDashboardService(version, baseURL, tq, ms, ir, js, is)
 }
 
 // GetVersion returns the version string for use by handlers.

--- a/internal/chief/usecase/dashboard.go
+++ b/internal/chief/usecase/dashboard.go
@@ -21,6 +21,7 @@ var dashboardTmplStr string
 
 type DashboardData struct {
 	Version       string
+	BaseURL       string
 	Maintainers   []domain.Maintainer
 	HasMonitoring bool
 	Summary       SummaryView
@@ -93,6 +94,7 @@ type ISOJobView struct {
 // DashboardService renders the chief dashboard HTML.
 type DashboardService struct {
 	version       string
+	baseURL       string
 	taskQueue     TaskQueue
 	maintainerSvc *MaintainerService
 	registry      InstanceRegistry
@@ -103,6 +105,7 @@ type DashboardService struct {
 
 func NewDashboardService(
 	version string,
+	baseURL string,
 	taskQueue TaskQueue,
 	maintainerSvc *MaintainerService,
 	registry InstanceRegistry,
@@ -115,6 +118,7 @@ func NewDashboardService(
 	}
 	return &DashboardService{
 		version:       version,
+		baseURL:       baseURL,
 		taskQueue:     taskQueue,
 		maintainerSvc: maintainerSvc,
 		registry:      registry,
@@ -132,6 +136,7 @@ func (d *DashboardService) RenderIndexHTML(w io.Writer) error {
 func (d *DashboardService) buildDashboardData() DashboardData {
 	data := DashboardData{
 		Version:     d.version,
+		BaseURL:     d.baseURL,
 		Maintainers: d.maintainerSvc.GetMaintainers(),
 	}
 

--- a/internal/chief/usecase/dashboard.go
+++ b/internal/chief/usecase/dashboard.go
@@ -112,7 +112,11 @@ func NewDashboardService(
 	jobStore JobStore,
 	isoStore ISOJobStore,
 ) (*DashboardService, error) {
-	tmpl, err := template.New("dashboard").Parse(dashboardTmplStr)
+	tmpl, err := template.New("dashboard").Funcs(template.FuncMap{
+		"baseurl": func(p string) string {
+			return baseURL + p
+		},
+	}).Parse(dashboardTmplStr)
 	if err != nil {
 		return nil, fmt.Errorf("parse dashboard template: %w", err)
 	}

--- a/internal/chief/usecase/dashboard_test.go
+++ b/internal/chief/usecase/dashboard_test.go
@@ -295,7 +295,7 @@ func TestDashboardService_RenderIndexHTML(t *testing.T) {
 	}
 	maintainerSvc := NewMaintainerService(gpg)
 
-	ds, err := NewDashboardService("1.0.0", &mockTaskQueue{}, maintainerSvc, nil, nil, nil)
+	ds, err := NewDashboardService("1.0.0", "/irgsh", &mockTaskQueue{}, maintainerSvc, nil, nil, nil)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer

--- a/internal/chief/usecase/templates/dashboard.html
+++ b/internal/chief/usecase/templates/dashboard.html
@@ -252,8 +252,8 @@
                 <td>{{.PackageVersion}}</td>
                 <td>{{.Maintainer}}</td>
                 <td>{{.Component}}</td>
-                <td><span class="{{.BuildStageClass}}">{{.BuildStateText}}</span><br><a href="/logs/{{.TaskUUID}}.build.log" target="_blank" style="font-size:0.85em;">log</a></td>
-                <td><span class="{{.RepoStageClass}}">{{.RepoStateText}}</span><br><a href="/logs/{{.TaskUUID}}.repo.log" target="_blank" style="font-size:0.85em;">log</a></td>
+                <td><span class="{{.BuildStageClass}}">{{.BuildStateText}}</span><br><a href="{{$.BaseURL}}/logs/{{.TaskUUID}}.build.log" target="_blank" style="font-size:0.85em;">log</a></td>
+                <td><span class="{{.RepoStageClass}}">{{.RepoStateText}}</span><br><a href="{{$.BaseURL}}/logs/{{.TaskUUID}}.repo.log" target="_blank" style="font-size:0.85em;">log</a></td>
                 <td>
                     {{- if .ShowSpinner}}
                     <svg class="spinning-gear" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff9800" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>

--- a/internal/chief/usecase/templates/dashboard.html
+++ b/internal/chief/usecase/templates/dashboard.html
@@ -252,8 +252,8 @@
                 <td>{{.PackageVersion}}</td>
                 <td>{{.Maintainer}}</td>
                 <td>{{.Component}}</td>
-                <td><span class="{{.BuildStageClass}}">{{.BuildStateText}}</span><br><a href="{{$.BaseURL}}/logs/{{.TaskUUID}}.build.log" target="_blank" style="font-size:0.85em;">log</a></td>
-                <td><span class="{{.RepoStageClass}}">{{.RepoStateText}}</span><br><a href="{{$.BaseURL}}/logs/{{.TaskUUID}}.repo.log" target="_blank" style="font-size:0.85em;">log</a></td>
+                <td><span class="{{.BuildStageClass}}">{{.BuildStateText}}</span><br><a href="{{baseurl (printf "/logs/%s.build.log" .TaskUUID)}}" target="_blank" style="font-size:0.85em;">log</a></td>
+                <td><span class="{{.RepoStageClass}}">{{.RepoStateText}}</span><br><a href="{{baseurl (printf "/logs/%s.repo.log" .TaskUUID)}}" target="_blank" style="font-size:0.85em;">log</a></td>
                 <td>
                     {{- if .ShowSpinner}}
                     <svg class="spinning-gear" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#ff9800" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -24,9 +25,11 @@ type IrgshConfig struct {
 }
 
 type ChiefConfig struct {
-	Address  string `json:"address" validate:"required"`
-	Workdir  string `json:"workdir" validate:"required"`
-	GnupgDir string `json:"gnupg_dir" validate:"required"` // GNUPG dir path
+	Address   string `json:"address" validate:"required"`
+	BaseURL   string `json:"base_url" validate:"baseurl"`
+	PublicURL string `json:"public_url"`
+	Workdir   string `json:"workdir" validate:"required"`
+	GnupgDir  string `json:"gnupg_dir" validate:"required"` // GNUPG dir path
 }
 
 type BuilderConfig struct {
@@ -169,6 +172,23 @@ func applyDefaults(cfg *IrgshConfig) error {
 		cfg.Monitoring.CleanupInterval = 3600
 	}
 
+	normalizeChiefConfig(&cfg.Chief)
+
 	validate := validator.New()
+	validate.RegisterValidation("baseurl", func(fl validator.FieldLevel) bool {
+		re := regexp.MustCompile(`^/[A-Za-z0-9_\-/]*$`)
+		return fl.Field().String() == "" || re.MatchString(fl.Field().String())
+	})
 	return validate.Struct(cfg)
+}
+
+func normalizeChiefConfig(cfg *ChiefConfig) {
+	cfg.Address = strings.TrimSuffix(cfg.Address, "/")
+	cfg.PublicURL = strings.TrimSuffix(cfg.PublicURL, "/")
+
+	b := strings.TrimSuffix(cfg.BaseURL, "/")
+	if b != "" && !strings.HasPrefix(b, "/") {
+		b = "/" + b
+	}
+	cfg.BaseURL = b
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,9 @@ type IrgshConfig struct {
 	Storage      StorageConfig      `json:"storage"`
 	IsTest       bool               `json:"is_test"`
 	IsDev        bool               `json:"is_dev"`
+	// FullBaseURL is the externally-reachable base URL for log links, computed
+	// once at load time so workers don't repeat the public_url/base_url check.
+	FullBaseURL string `json:"-"`
 }
 
 type ChiefConfig struct {
@@ -175,6 +178,7 @@ func applyDefaults(cfg *IrgshConfig) error {
 	}
 
 	normalizeChiefConfig(&cfg.Chief)
+	cfg.FullBaseURL = computeFullBaseURL(&cfg.Chief)
 
 	validate := validator.New()
 	if err := validate.RegisterValidation("baseurl", func(fl validator.FieldLevel) bool {
@@ -194,4 +198,14 @@ func normalizeChiefConfig(cfg *ChiefConfig) {
 		b = "/" + b
 	}
 	cfg.BaseURL = b
+}
+
+// computeFullBaseURL returns the externally-reachable base URL for log links.
+// When public_url is set it is treated as the complete external URL; otherwise
+// the internal address is combined with base_url. Expects a normalized config.
+func computeFullBaseURL(cfg *ChiefConfig) string {
+	if cfg.PublicURL != "" {
+		return cfg.PublicURL
+	}
+	return cfg.Address + cfg.BaseURL
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	validator "gopkg.in/go-playground/validator.v9"
 )
 
+var baseURLRegex = regexp.MustCompile(`^/[A-Za-z0-9_\-/]*$`)
+
 type IrgshConfig struct {
 	Redis        string             `json:"redis"`
 	Chief        ChiefConfig        `json:"chief"`
@@ -175,10 +177,11 @@ func applyDefaults(cfg *IrgshConfig) error {
 	normalizeChiefConfig(&cfg.Chief)
 
 	validate := validator.New()
-	validate.RegisterValidation("baseurl", func(fl validator.FieldLevel) bool {
-		re := regexp.MustCompile(`^/[A-Za-z0-9_\-/]*$`)
-		return fl.Field().String() == "" || re.MatchString(fl.Field().String())
-	})
+	if err := validate.RegisterValidation("baseurl", func(fl validator.FieldLevel) bool {
+		return fl.Field().String() == "" || baseURLRegex.MatchString(fl.Field().String())
+	}); err != nil {
+		return err
+	}
 	return validate.Struct(cfg)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,3 +85,43 @@ func TestNormalizeChiefConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseURLValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{"valid", "/irgsh", false},
+		{"valid nested", "/api/v1", false},
+		{"valid with hyphen", "/irgsh-go", false},
+		{"valid with underscore", "/irgsh_go", false},
+		{"empty", "", false},
+		{"invalid space", "/irgsh go", true},
+		{"invalid query", "/irgsh?a=b", true},
+		{"invalid control", "/irgsh\n", true},
+		{"invalid protocol", "http://irgsh", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &IrgshConfig{
+				Chief: ChiefConfig{
+					Address:  "http://localhost:8080",
+					Workdir:  "/tmp",
+					GnupgDir: "/tmp",
+					BaseURL:  tt.baseURL,
+				},
+				Builder: BuilderConfig{
+					Workdir:              "/tmp",
+					UpstreamDistCodename: "sid",
+					UpstreamDistUrl:      "http://deb.debian.org/debian",
+				},
+			}
+			err := applyDefaults(cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applyDefaults() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestNormalizeChiefConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     ChiefConfig
+		wantAddr  string
+		wantBase  string
+		wantPublic string
+	}{
+		{
+			name: "trailing slashes",
+			input: ChiefConfig{
+				Address:   "http://localhost:8080/",
+				BaseURL:   "/irgsh/",
+				PublicURL: "https://irgsh.id/",
+			},
+			wantAddr:  "http://localhost:8080",
+			wantBase:  "/irgsh",
+			wantPublic: "https://irgsh.id",
+		},
+		{
+			name: "missing leading slash on base_url",
+			input: ChiefConfig{
+				Address:   "http://localhost:8080",
+				BaseURL:   "irgsh",
+				PublicURL: "https://irgsh.id",
+			},
+			wantAddr:  "http://localhost:8080",
+			wantBase:  "/irgsh",
+			wantPublic: "https://irgsh.id",
+		},
+		{
+			name: "root base_url",
+			input: ChiefConfig{
+				Address:   "http://localhost:8080",
+				BaseURL:   "/",
+				PublicURL: "https://irgsh.id",
+			},
+			wantAddr:  "http://localhost:8080",
+			wantBase:  "",
+			wantPublic: "https://irgsh.id",
+		},
+		{
+			name: "empty values",
+			input: ChiefConfig{
+				Address:   "http://localhost:8080",
+				BaseURL:   "",
+				PublicURL: "",
+			},
+			wantAddr:  "http://localhost:8080",
+			wantBase:  "",
+			wantPublic: "",
+		},
+		{
+			name: "nested base_url",
+			input: ChiefConfig{
+				Address:   "http://localhost:8080",
+				BaseURL:   "/api/v1/",
+				PublicURL: "https://irgsh.id",
+			},
+			wantAddr:  "http://localhost:8080",
+			wantBase:  "/api/v1",
+			wantPublic: "https://irgsh.id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.input
+			normalizeChiefConfig(&cfg)
+			if cfg.Address != tt.wantAddr {
+				t.Errorf("normalizeChiefConfig() Address = %v, want %v", cfg.Address, tt.wantAddr)
+			}
+			if cfg.BaseURL != tt.wantBase {
+				t.Errorf("normalizeChiefConfig() BaseURL = %v, want %v", cfg.BaseURL, tt.wantBase)
+			}
+			if cfg.PublicURL != tt.wantPublic {
+				t.Errorf("normalizeChiefConfig() PublicURL = %v, want %v", cfg.PublicURL, tt.wantPublic)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,39 @@ func TestNormalizeChiefConfig(t *testing.T) {
 	}
 }
 
+func TestComputeFullBaseURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ChiefConfig
+		want  string
+	}{
+		{
+			name:  "public_url takes precedence",
+			input: ChiefConfig{Address: "http://localhost:8080", BaseURL: "/irgsh", PublicURL: "https://irgsh.id/irgsh"},
+			want:  "https://irgsh.id/irgsh",
+		},
+		{
+			name:  "fallback to address + base_url",
+			input: ChiefConfig{Address: "http://localhost:8080", BaseURL: "/irgsh", PublicURL: ""},
+			want:  "http://localhost:8080/irgsh",
+		},
+		{
+			name:  "fallback with empty base_url",
+			input: ChiefConfig{Address: "http://localhost:8080", BaseURL: "", PublicURL: ""},
+			want:  "http://localhost:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.input
+			if got := computeFullBaseURL(&cfg); got != tt.want {
+				t.Errorf("computeFullBaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBaseURLValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -121,6 +122,11 @@ func TestBaseURLValidation(t *testing.T) {
 			err := applyDefaults(cfg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applyDefaults() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil {
+				if !strings.Contains(strings.ToLower(err.Error()), "baseurl") {
+					t.Errorf("expected error to mention baseurl, got: %v", err)
+				}
 			}
 		})
 	}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -13,10 +13,6 @@ import (
 	"github.com/blankon/irgsh-go/pkg/httputil"
 )
 
-// LogBaseURL is the base URL for accessing build/repo logs
-// Change this constant if the IRGSH server URL changes
-const LogBaseURL = "http://irgsh.blankonlinux.id"
-
 // WebhookPayload represents the notification payload sent to webhook
 type WebhookPayload struct {
 	Title   string `json:"title"`
@@ -98,7 +94,7 @@ func extractRepoName(url string) string {
 }
 
 // SendJobNotification sends a job completion notification
-func SendJobNotification(webhookURL, jobType, taskUUID, status string, jobInfo JobNotificationInfo) {
+func SendJobNotification(webhookURL, logBaseURL, jobType, taskUUID, status string, jobInfo JobNotificationInfo) {
 	title := fmt.Sprintf("IRGSH %s Job %s", jobType, status)
 
 	// Add emoji based on status
@@ -172,16 +168,20 @@ func SendJobNotification(webhookURL, jobType, taskUUID, status string, jobInfo J
 
 	// Append log URL on failure
 	if status == "FAILED" {
-		var logType string
-		switch jobType {
-		case "Build":
-			logType = "build"
-		case "Repo":
-			logType = "repo"
-		}
-		if logType != "" {
-			logURL := fmt.Sprintf("%s/logs/%s.%s.log", LogBaseURL, taskUUID, logType)
-			message = fmt.Sprintf("%s\n%s", message, logURL)
+		if logBaseURL == "" {
+			log.Println("Warning: logBaseURL is empty, log link will be omitted from notification")
+		} else {
+			var logType string
+			switch jobType {
+			case "Build":
+				logType = "build"
+			case "Repo":
+				logType = "repo"
+			}
+			if logType != "" {
+				logURL := fmt.Sprintf("%s/logs/%s.%s.log", logBaseURL, taskUUID, logType)
+				message = fmt.Sprintf("%s\n%s", message, logURL)
+			}
 		}
 	}
 

--- a/utils/config.yaml
+++ b/utils/config.yaml
@@ -17,6 +17,8 @@ storage:
 
 chief:
   address: 'http://localhost:8080'
+  # base_url: '/irgsh'
+  # public_url: 'http://irgsh.blankonlinux.id'
   workdir: '/var/lib/irgsh/chief'
   gnupg_dir: '/var/lib/irgsh/gnupg'
 

--- a/utils/config.yaml
+++ b/utils/config.yaml
@@ -18,7 +18,7 @@ storage:
 chief:
   address: 'http://localhost:8080'
   # base_url: '/irgsh'
-  # public_url: 'http://irgsh.blankonlinux.id'
+  # public_url: 'http://irgsh.blankonlinux.id' # full external URL, ignores base_url if set
   workdir: '/var/lib/irgsh/chief'
   gnupg_dir: '/var/lib/irgsh/gnupg'
 


### PR DESCRIPTION
feat: allow irgsh-chief to run under a sub-path with base_url (v2)

Description Thank you for the detailed feedback on the previous iteration. I have refactored the implementation to address all blockers and design concerns. This version ensures full backward compatibility with workers while providing a robust sub-path support for the dashboard.

  Addresssed Feedback & Improvements

1. Clean utils/config.yaml (Blocker #1)
   - Reverted all accidental local edits (indentation, redis host, signing keys, etc.) to match upstream exactly.
   - Only added optional commented examples for base_url and public_url under the chief section.
   - Restored iso.public_base_url to prevent regression.
  
2. Dual-Mux Routing for Worker Compatibility (Blocker #2)
   - Implemented Option 3: The inner mux is now registered at both the root (/) and the prefix (BaseURL/).
   - Result: Workers can still reach /api/v1/* at the root without any config changes, while the dashboard and user routes are accessible via the sub-path.

3. Dedicated PublicURL & Proper Normalization (Design #3 & #4)
   - Added a separate public_url field in ChiefConfig to distinguish between internal listen addresses and external-facing
     URLs.
   - Created a normalizeChiefConfig function that trims trailing slashes from Address, PublicURL, and BaseURL to prevent
     double-slash issues (//logs/...).

4. Strict BaseURL Validation (Design #5)
   - Added a custom Regex validator (^/[A-Za-z0-9_\-/]*$) registered in applyDefaults.
   - This catches invalid characters (spaces, query strings, etc.) during configuration load.

5. Enhanced Testing & Refactoring (Nit #6 & #7)
   - Refactored internal/config/config_test.go to provide a complete valid config, ensuring the validator doesn't swallow
     unrelated errors.
   - Extracted and unit-tested normalizeChiefConfig directly.
   - Simplified the normalization logic using the suggested collapsed branch.

6. Visibility & Maintainability (Nit #8 & #9)
   - Added a log.Println warning when a notification is sent without a logBaseURL, making misconfigurations visible.
   - Introduced a baseurl template helper in the dashboard. All internal links now use this helper, ensuring sub-path
     consistency across the UI.
Verification Results
   - Unit Tests: All tests passed (go test ./internal/config/... ./internal/chief/usecase/...).
   - Manual E2E: Verified that curl http://localhost:8080/api/v1/version works (Worker path) AND http://localhost:8080/irgsh/ serves the dashboard (User path).
   - Log Links: Verified log links in the dashboard correctly point to /irgsh/logs/....

Fixes
   - Fixes #161